### PR TITLE
Fix typo, fixing LDAP CN authentication

### DIFF
--- a/src/java/org/openedit/users/authenticate/LdapAuthenticator.java
+++ b/src/java/org/openedit/users/authenticate/LdapAuthenticator.java
@@ -77,7 +77,7 @@ public class LdapAuthenticator extends BaseAuthenticator
 		}
         Data postfix = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserverpostfix");
 		String spostfix = null;
-		if( spostfix != null)
+		if( postfix != null)
 		{
 			spostfix = postfix.get("value");
 		}

--- a/src/java/org/openedit/users/authenticate/LdapAuthenticator.java
+++ b/src/java/org/openedit/users/authenticate/LdapAuthenticator.java
@@ -6,11 +6,14 @@ package org.openedit.users.authenticate;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.naming.NamingException;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openedit.Data;
 import org.openedit.data.Searcher;
 import org.openedit.data.SearcherManager;
+import org.openedit.hittracker.HitTracker;
 import org.openedit.users.User;
 import org.openedit.users.UserManagerException;
 import org.openedit.util.LDAP;
@@ -64,26 +67,93 @@ public class LdapAuthenticator extends BaseAuthenticator
         	return false;
         }
         
+        //Set a user string
+        String inUsername = inUser.getUserName();
+
+        //Set a password string
+        String inPassword = inAReq.getPassword();
+        //log.info("Ldap Server Password:"+ inPassword);
+
+        //Create a new Ldap instance
         LDAP ldap = new LDAP( server.get("value"));
-		
-        Data prefix = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserverprefix");
         
-		String inPassword = inAReq.getPassword();
-		
-		String sprefix = null;
-		if( prefix != null)
-		{
-			sprefix = prefix.get("value");
-		}
+        //log.info("New Ldap Init");
+
+        //Lookup the DN
+        Data searchdn = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserversearchdn");
+
+        //Make a string from the result or null
+        String searchDN = ( searchdn.get("value") != null ) ?  searchdn.get("value") : null;
+
+        //log.info("New Ldap Search DN " + searchDN);
+
+        //Lookup the field to search with
+        Data searchfield = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserversearchfield");
+
+        //Make a string from the result or null
+        String searchField = ( searchfield.get("value") != null ) ?  searchfield.get("value") : null;
+
+		//log.info("New Ldap Search Field " + searchField);
+
+        //If the admin supplied a search field, we need to search ldap for the supplied value under this field and return the CN
+        if( searchField != null)
+        {
+			//log.info("NOT NULL Search Field " + searchField);
+
+			//We may need to tell the auth to go no auth, we can't trust the user has the read permissions for this operation.?
+			ldap.setAuth("none");
+
+			//log.info("Auth set to none");
+
+			//If the search DN is set, set it
+			if(searchDN != null) {
+				ldap.setDN(searchDN);  //Is setdomain the same?, authenticate suggests not.
+				ldap.setDomain(searchDN);
+				log.info("Search DN Set");
+			}
+
+			//Search LDAP For the results
+			HitTracker<?> searchResult = ldap.search( searchField, inUser.getUserName() );
+
+			try {
+				//Try to set the login username for LDAP, we will keep the supplied ID
+				inUsername = searchResult.get(0).getValue("cn").toString();
+			}catch(Exception e) {
+				//No entries... some kind of error, or no results.
+				log.error( "Unable to find user at LDAP server");
+			}
+
+			ldap = new LDAP( server.get("value"));
+
+			//Return back to normal values for the bind
+			//ldap.setAuth("simple");
+
+			//log.info("Auth set to simple");
+			//Authenticate will take care of resetting the DN
+
+        }
+
+        //Get the prefix for ldap binding
+        Data prefix = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserverprefix");
+
+		//Check the prefix and make a string
+		String sprefix  = ( prefix != null ) ? prefix.get("value") : null;
+
+        //log.info("New Ldap Prefix Field " + sprefix);
+
+		//Check the post fix
         Data postfix = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserverpostfix");
-		String spostfix = null;
-		if( postfix != null)
-		{
-			spostfix = postfix.get("value");
-		}
-		
-		ldap.authenticate(sprefix,inUser.getUserName(), spostfix, inPassword);
-		
+
+        //Check the postfix and make a string
+		String spostfix = ( postfix != null) ?  postfix.get("value") : null;
+
+        //log.info("New Ldap Postfix Field " + spostfix);
+
+		//Authenticate with Ldap
+		ldap.authenticate(sprefix, inUsername, spostfix, inPassword);
+
+
+		//If we have a connection
 		if (ldap.connect())
 		{
 //	        Data usersearch = getSearcherManager().getData(inAReq.getCatalogId(), "catalogsettings", "ldapserverusersearch");

--- a/src/java/org/openedit/util/LDAP.java
+++ b/src/java/org/openedit/util/LDAP.java
@@ -77,15 +77,19 @@ public class LDAP
 	public void init(String inServerName)
 	{
 		Properties env = getEnvironment();
-		env.put(Context.INITIAL_CONTEXT_FACTORY,
-				"com.sun.jndi.ldap.LdapCtxFactory");
-
+		env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
 		if (!inServerName.startsWith("ldap"))
 		{
 			throw new OpenEditException("ldapserver value must start with ldap");
 		}
 		env.put(Context.PROVIDER_URL, inServerName);	
 		log.info("[LDAP] Connecting to " + inServerName);
+	}
+	public void setAuth(String mode) {
+		getEnvironment().put(Context.SECURITY_AUTHENTICATION, mode);
+	}
+	public void setDN(String dn){
+		getEnvironment().put(Context.SECURITY_PRINCIPAL, dn);
 	}
 	public void authenticate(User inUser, String inPassword)
 	{
@@ -107,11 +111,11 @@ public class LDAP
 			//dnbuffer.append(",");
 			dnbuffer.append(postfix);
 		}
-		//uid=%s,ou=People,dc=company,dc=com
-		// String base = "ou=People,dc=example,dc=com";
-		// String dn = "uid=" + inUser.getUserName() + "," + base;
 		log.info("LDAP login: " + dnbuffer.toString());
+		//Get domain fails with null on search if not set
+		setDomain(dnbuffer.toString()); //This should maybe set the env? instead of having the next line?
 		getEnvironment().put(Context.SECURITY_PRINCIPAL, dnbuffer.toString());
+		//Set the env password
 		getEnvironment().put(Context.SECURITY_CREDENTIALS, inPassword);
 
 	}
@@ -201,6 +205,8 @@ public class LDAP
 		{
 			query = "(" + searchby + "=" + value + ")";
 		}
+		//log.info("LDAP query = " + query);
+		//log.info("LDAP Domain = " + getDomain());
 		return search(getDomain(), query, getMaxLdapResults());
 	}			
 


### PR DESCRIPTION
spostfix != postfix

Fixed a typo that prevented the postfix from being parsed from catalogsettings, likely preventing login.